### PR TITLE
Add scope to book token command

### DIFF
--- a/cmd/book/cmd/token.go
+++ b/cmd/book/cmd/token.go
@@ -50,6 +50,7 @@ bearer=$(book token)
 		viper.SetDefault("admin", "false")
 		viper.SetDefault("audience", "https://book.practable.io")
 		viper.SetDefault("groups", "everyone")
+		viper.SetDefault("addscope", "")
 
 		lifetime := viper.GetInt64("lifetime")
 		audience := viper.GetString("audience")
@@ -57,6 +58,7 @@ bearer=$(book token)
 		rawgroups := viper.GetString("groups")
 		groups := strings.Split(rawgroups, " ")
 		admin := viper.GetBool("admin")
+		addscope := viper.GetString("addscope")
 
 		// check inputs
 
@@ -84,6 +86,10 @@ bearer=$(book token)
 			scopes = []string{"login:admin"}
 		} else {
 			scopes = []string{"login:user"}
+		}
+
+		if addscope != "" {
+			scopes = append(scopes, addscope)
 		}
 
 		iat := time.Now().Unix() - 1 //ensure immediately usable


### PR DESCRIPTION
Fix Issue #11 

The book token command needed extending to support a new scope,
login:multiple. Rather than hardcode this extra scope, a new parameter
has been added to the command, so that a new scope can be added by
setting the environment variable BOOKTOKEN_ADDSCOPE.

[Issue: 11]