### PR TITLE
fix(cmd): update import path

### DIFF
--- a/cmd/book/cmd/root.go
+++ b/cmd/book/cmd/root.go
@@ -17,82 +17,72 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
-  "fmt"
-  "os"
-  "github.com/spf13/cobra"
+	"fmt"
+	"os"
 
-  homedir "github.com/mitchellh/go-homedir"
-  "github.com/spf13/viper"
+	"github.com/spf13/cobra"
 
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/spf13/viper"
 )
-
 
 var cfgFile string
 
-
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-  Use:   "book",
-  Short: "A brief description of your application",
-  Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-  // Uncomment the following line if your bare application
-  // has an action associated with it:
-  //	Run: func(cmd *cobra.Command, args []string) { },
+	Use:   "book",
+	Short: "booking server and client",
+	Long: `Book provides commands for a booking server and client, including 
+managing instant-access bookings for equipment, uploading bookings, resetting
+the booking server, getting the booking server status, and generating new
+tokens to access the booking server.`,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-  if err := rootCmd.Execute(); err != nil {
-    fmt.Println(err)
-    os.Exit(1)
-  }
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }
 
 func init() {
-  cobra.OnInitialize(initConfig)
+	cobra.OnInitialize(initConfig)
 
-  // Here you will define your flags and configuration settings.
-  // Cobra supports persistent flags, which, if defined here,
-  // will be global for your application.
+	// Here you will define your flags and configuration settings.
+	// Cobra supports persistent flags, which, if defined here,
+	// will be global for your application.
 
-  rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.book.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.book.yaml)")
 
-
-  // Cobra also supports local flags, which will only run
-  // when this action is called directly.
-  rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
-
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-  if cfgFile != "" {
-    // Use config file from the flag.
-    viper.SetConfigFile(cfgFile)
-  } else {
-    // Find home directory.
-    home, err := homedir.Dir()
-    if err != nil {
-      fmt.Println(err)
-      os.Exit(1)
-    }
+	if cfgFile != "" {
+		// Use config file from the flag.
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// Find home directory.
+		home, err := homedir.Dir()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 
-    // Search config in home directory with name ".book" (without extension).
-    viper.AddConfigPath(home)
-    viper.SetConfigName(".book")
-  }
+		// Search config in home directory with name ".book" (without extension).
+		viper.AddConfigPath(home)
+		viper.SetConfigName(".book")
+	}
 
-  viper.AutomaticEnv() // read in environment variables that match
+	viper.AutomaticEnv() // read in environment variables that match
 
-  // If a config file is found, read it in.
-  if err := viper.ReadInConfig(); err == nil {
-    fmt.Println("Using config file:", viper.ConfigFileUsed())
-  }
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	}
 }
-

--- a/cmd/book/main.go
+++ b/cmd/book/main.go
@@ -16,8 +16,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 package main
 
-import "github.com/timdrysdale/relay/cmd/book/cmd"
+import "github.com/practable/relay/cmd/book/cmd"
 
 func main() {
-  cmd.Execute()
+	cmd.Execute()
 }

--- a/cmd/session/main.go
+++ b/cmd/session/main.go
@@ -16,8 +16,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 package main
 
-import "github.com/timdrysdale/relay/cmd/session/cmd"
+import "github.com/practable/relay/cmd/session/cmd"
 
 func main() {
-  cmd.Execute()
+	cmd.Execute()
 }

--- a/cmd/shell/cmd/root.go
+++ b/cmd/shell/cmd/root.go
@@ -30,17 +30,15 @@ var logFile string
 var rootCmd = &cobra.Command{
 	Use:   "shell",
 	Short: "Shell is a set of services for relaying ssh connections",
-	Long: `Available services are 
+	Long: `Shell is a set of services for relaying ssh connections.
+Three services required in total for a single connection:
+  host: the unattended remote machine 
+  client: the attended local machine 
+  relay: runs at a public IP address, shared out of band with the host and client
 
-session relay := relays websockets, with jwt-token protected access via separate http API
-session host := connects to local sshd dameon (or whatever other login shell you are relaying)
-session client := listens at a local port for connections from your ssh tool
+A relay can handle multiple connections. An administrator with multiple hosts to access, 
+should start a separate client instance for each host they wish to connect to.
 `,
-
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	//Run: func(cmd *cobra.Command, args []string) {
-	//},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/shell/main.go
+++ b/cmd/shell/main.go
@@ -16,8 +16,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 package main
 
-import "github.com/timdrysdale/relay/cmd/shell/cmd"
+import "github.com/practable/relay/cmd/shell/cmd"
 
 func main() {
-  cmd.Execute()
+	cmd.Execute()
 }


### PR DESCRIPTION
A couple of stray references to the old home of the package (github.com/timdrysdale/relay) broke some of the subcommands in session, book and shell. Now fixed, with an update to the help message in the commands too.