### PR TITLE
Fix session client file playback

### DIFF
--- a/cmd/session/cmd/file.go
+++ b/cmd/session/cmd/file.go
@@ -327,6 +327,7 @@ kill -SIGHUP pid
 		go func() {
 			for range c {
 				cancel()
+				log.Infof("Stopping normally due to Ctrl-C or SIGINT")
 				os.Exit(0)
 			}
 		}()
@@ -337,6 +338,7 @@ kill -SIGHUP pid
 		err := file.Run(ctx, sighup, session, token, logfilename, playfilename, interval, check, force)
 		if err != nil {
 			fmt.Println(err.Error())
+			log.Errorf("Stopping due to error: %s", err.Error())
 			os.Exit(1)
 		}
 

--- a/cmd/session/cmd/file.go
+++ b/cmd/session/cmd/file.go
@@ -24,6 +24,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/practable/relay/internal/file"
 	log "github.com/sirupsen/logrus"
@@ -306,14 +307,18 @@ kill -SIGHUP pid
 				playfilename,
 				strconv.FormatBool(check),
 				strconv.FormatBool(check))
-			log.SetFormatter(&log.TextFormatter{})
+			Formatter := new(log.TextFormatter)
+			Formatter.TimestampFormat = time.RFC3339Nano
+			log.SetFormatter(Formatter)
 			log.SetLevel(log.TraceLevel)
 			log.SetOutput(os.Stdout)
 
 		} else {
 
 			//production environment
-			log.SetFormatter(&log.JSONFormatter{})
+			Formatter := new(log.JSONFormatter)
+			Formatter.TimestampFormat = time.RFC3339Nano
+			log.SetFormatter(Formatter)
 			log.SetLevel(log.InfoLevel)
 
 		}

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -80,17 +80,17 @@ func Run(ctx context.Context, hup chan os.Signal, session, token, logfilename, p
 
 		// listen for sighup until we are done, or exiting
 		go func() {
-			log.Info("starting listening for sighup") //TODO demote to debug after fix
+			log.Debug("starting listening for sighup")
 			for {
 				select {
 				case <-done:
-					log.Info("done, finished playfile? No longer listening for signup")
+					log.Debug("done, finished playfile? No longer listening for signup")
 					return // we've finished the playfile, most likely
 				case <-ctx.Done():
-					log.Info("Context cancelled, no longer listening for signup")
+					log.Debug("Context cancelled, no longer listening for signup")
 					return //avoid leaking this goroutine if we are cancelled
 				case <-hup:
-					log.Infof("SIGHUP detected, reopening LOG file %s\n", logfilename)
+					log.Infof("SIGHUP detected, reopening file %s", logfilename)
 					err := f.Reopen()
 					if err != nil {
 						log.Errorf("error reopening file: %s", err.Error())

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -106,6 +106,8 @@ func Run(ctx context.Context, hup chan os.Signal, session, token, logfilename, p
 
 	go r.ReconnectAuth(ctx, session, token)
 
+	time.Sleep(time.Second) //TODO replace with a signal that connection is made
+
 	//channel for writing FilterActions
 	a := make(chan FilterAction, 10)
 
@@ -149,6 +151,7 @@ func Run(ctx context.Context, hup chan os.Signal, session, token, logfilename, p
 		for {
 			select {
 			case <-ctx.Done():
+				log.Debugf("file.Run() cancelled")
 				return
 			case msg := <-s:
 				r.Out <- reconws.WsMessage{Type: websocket.TextMessage, Data: []byte(msg)}
@@ -161,6 +164,7 @@ func Run(ctx context.Context, hup chan os.Signal, session, token, logfilename, p
 		close := make(chan struct{})
 		go Play(ctx, close, lines, a, s, c, w)
 		<-close //Play closes close when it has finished playing the file
+		log.Debugf("file.Run(): Play() complete")
 
 	} else {
 

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -360,7 +360,7 @@ ah
 	// failures when it's a limitation of the testing,
 	// due to impact on github actions when uploading other code.
 
-	assert.GreaterOrEqual(t, expectedCount, idx-2, "incorrect number of lines in file")
+	assert.GreaterOrEqual(t, expectedCount, idx, "incorrect number of lines in file")
 
 	time.Sleep(time.Second)
 

--- a/internal/file/parse.go
+++ b/internal/file/parse.go
@@ -156,7 +156,15 @@ func Play(ctx context.Context, closed chan struct{}, lines []interface{}, a chan
 			log.Infof("Line %d [Send %s] (sent): %s", idx, action, line.Msg)
 
 		case FilterAction:
-			log.Infof("Line %d [FilterAction/%s] %s", idx, line.Verb.String(), line.Pattern.String())
+
+			var pattern string
+
+			if line.Pattern != nil {
+				pattern = line.Pattern.String()
+			}
+
+			log.Infof("Line %d [FilterAction/%s] %s", idx, line.Verb.String(), pattern)
+
 			a <- line
 		default:
 			log.Errorf("Line %d [Unknown, ignoring line]", idx)

--- a/internal/file/parse_test.go
+++ b/internal/file/parse_test.go
@@ -241,9 +241,12 @@ goodbye
 
 	pout := make(chan interface{}, n)
 
-	err := ParseByLine(strings.NewReader(play), pout)
-
-	assert.NoError(t, err)
+	go func() {
+		// won't complete until last value read from channel
+		err := ParseByLine(strings.NewReader(play), pout)
+		assert.NoError(t, err)
+		t.Logf("ParseByLine completed")
+	}()
 
 	lines := []interface{}{}
 
@@ -505,9 +508,12 @@ func TestParseByLine(t *testing.T) {
 
 	out := make(chan interface{}, n) // buffer >= lines in s to avoid hang
 
-	err := ParseByLine(in, out)
-
-	assert.NoError(t, err)
+	go func() {
+		// won't complete until last value read from channel
+		err := ParseByLine(in, out)
+		assert.NoError(t, err)
+		t.Logf("ParseByLine completed")
+	}()
 
 	idx := 0
 	for o := range out {

--- a/internal/file/types.go
+++ b/internal/file/types.go
@@ -48,7 +48,7 @@ type Condition struct {
 // that mimics its representation in .play file
 // <AcceptPattern, Count, Timeout>
 func (c *Condition) String() string {
-	return fmt.Sprintf("<%s,%d,%s>",
+	return fmt.Sprintf("('%s',%d,%s)",
 		c.AcceptPattern.String(),
 		c.Count,
 		c.Timeout)
@@ -87,6 +87,22 @@ const (
 	// Remove all AcceptPattern and DenyPatterns (make filter all-pass again)
 	Reset
 )
+
+func (v *FilterVerb) String() string {
+
+	switch *v {
+	case Unknown:
+		return "unknown"
+	case Accept:
+		return "accept"
+	case Deny:
+		return "deny"
+	case Reset:
+		return "reset"
+	default:
+		return ""
+	}
+}
 
 // Line represents content of a line received from the relay
 // and the time it was received.

--- a/scripts/examples/session_client/log-norotate.sh
+++ b/scripts/examples/session_client/log-norotate.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# example ./log-only.sh 86400 spin35-data $HOME/tmp
+
+# Make token 
+export ACCESSTOKEN_LIFETIME=$1
+export ACCESSTOKEN_ROLE=client
+export ACCESSTOKEN_SECRET=$($HOME/secret/session_secret.sh)
+export ACCESSTOKEN_TOPIC=$2
+export ACCESSTOKEN_CONNECTIONTYPE=session
+export ACCESSTOKEN_AUDIENCE=https://relay-access.practable.io
+export SESSION_CLIENT_TOKEN=$(session token)
+
+# set up other options
+export SESSION_CLIENT_SESSION=$ACCESSTOKEN_AUDIENCE/$ACCESSTOKEN_CONNECTIONTYPE/$ACCESSTOKEN_TOPIC
+mkdir -p $3
+export SESSION_CLIENT_FILE_LOG=$3/session.log
+../../../cmd/session/session client file 
+


### PR DESCRIPTION
The last line of the play file was omitted sometimes. Fixed by making LoadFile wait until all results read from channel before closing channel. Logging tidied up as well.